### PR TITLE
Bump deps and SDK constraint to version solve in dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Widen SDK constraint to include 2.0.0.
+
 ## 1.0.1
 
 * Fix the homepage URL.

--- a/lib/typed_data.dart
+++ b/lib/typed_data.dart
@@ -5,8 +5,8 @@
 import 'dart:typed_data' as typed_data;
 
 abstract class Endianness {
-  static const big = typed_data.Endianness.BIG_ENDIAN;
-  static const little = typed_data.Endianness.LITTLE_ENDIAN;
+  static const big = typed_data.Endian.big;
+  static const little = typed_data.Endian.little;
 }
 
 abstract class Int8List {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: dart2_constant
-version: 1.0.1+dart2
+version: 1.0.2+dart2
 description: A polyfill for Dart 2 constant names.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/dart2_constant
 
 environment:
-  sdk: '>=2.0.0-dev.34.0 <2.0.0'
+  sdk: '>=2.0.0-dev.34.0 <3.0.0'
 
 dev_dependencies:
   args: "^1.0.0"
-  analyzer: ">=0.30.0 <0.32.0"
+  analyzer: ">=0.30.0 <0.33.0"
   dart_style: "^1.0.0"
   path: "^1.0.0"


### PR DESCRIPTION
Now fixed to include all the history for the dart2 release.