### PR TITLE
Add support for HttpHeaders for Dart 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- stable
+- "1.24.3"
 
 dart_task:
 - dartanalyzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.2
+
+* Support ContentType constants.
+* Support InternetAddress constants.
+* Support HttpHeaders constants.
+* Update travis to use the latest Dart1 version, 1.24.3.
+
 ## 1.0.1
 
 * Fix the homepage URL.

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -158,6 +158,13 @@ abstract class HttpHeaders {
   static const requestHeadersHeader = io.HttpHeaders.REQUEST_HEADERS;
 }
 
+abstract class ContentType {
+  static final binary = io.ContentType.BINARY;
+  static final html = io.ContentType.HTML;
+  static final json = io.ContentType.JSON;
+  static final text = io.ContentType.TEXT;
+}
+
 abstract class HttpClient {
   static const defaultHttpPort = io.HttpClient.DEFAULT_HTTP_PORT;
   static const defaultHttpsPort = io.HttpClient.DEFAULT_HTTPS_PORT;
@@ -199,6 +206,13 @@ abstract class InternetAddressType {
   static const ipV4 = io.InternetAddressType.IP_V4;
   static const ipV6 = io.InternetAddressType.IP_V6;
   static const any = io.InternetAddressType.ANY;
+}
+
+abstract class InternetAddress {
+  static final anyIPv4 = io.InternetAddress.ANY_IP_V4;
+  static final anyIPv6 = io.InternetAddress.ANY_IP_V6;
+  static final loopbackIPv4 = io.InternetAddress.LOOPBACK_IP_V4;
+  static final loopbackIPv6 = io.InternetAddress.LOOPBACK_IP_V6;
 }
 
 abstract class SocketDirection {

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -102,6 +102,62 @@ abstract class HttpStatus {
       io.HttpStatus.NETWORK_CONNECT_TIMEOUT_ERROR;
 }
 
+abstract class HttpHeaders {
+  static const acceptHeader = io.HttpHeaders.ACCEPT;
+  static const acceptCharsetHeader = io.HttpHeaders.ACCEPT_CHARSET;
+  static const acceptEncodingHeader = io.HttpHeaders.ACCEPT_ENCODING;
+  static const acceptLanguageHeader = io.HttpHeaders.ACCEPT_LANGUAGE;
+  static const acceptRangesHeader = io.HttpHeaders.ACCEPT_RANGES;
+  static const ageHeader = io.HttpHeaders.AGE;
+  static const allowHeader = io.HttpHeaders.ALLOW;
+  static const authorizationHeader = io.HttpHeaders.AUTHORIZATION;
+  static const cacheControlHeader = io.HttpHeaders.CACHE_CONTROL;
+  static const connectionHeader = io.HttpHeaders.CONNECTION;
+  static const contentEncodingHeader = io.HttpHeaders.CONTENT_ENCODING;
+  static const contentLanguageHeader = io.HttpHeaders.CONTENT_LANGUAGE;
+  static const contentLengthHeader = io.HttpHeaders.CONTENT_LENGTH;
+  static const contentLocationHeader = io.HttpHeaders.CONTENT_LOCATION;
+  static const contentMd5Header = io.HttpHeaders.CONTENT_MD5;
+  static const contentRangeHeader = io.HttpHeaders.CONTENT_RANGE;
+  static const contentTypeHeader = io.HttpHeaders.CONTENT_TYPE;
+  static const dateHeader = io.HttpHeaders.DATE;
+  static const etagHeader = io.HttpHeaders.ETAG;
+  static const expectHeader = io.HttpHeaders.EXPECT;
+  static const expiresHeader = io.HttpHeaders.EXPIRES;
+  static const fromHeader = io.HttpHeaders.FROM;
+  static const hostHeader = io.HttpHeaders.HOST;
+  static const ifMatchHeader = io.HttpHeaders.IF_MATCH;
+  static const ifModifiedSinceHeader = io.HttpHeaders.IF_MODIFIED_SINCE;
+  static const ifNoneMatchHeader = io.HttpHeaders.IF_NONE_MATCH;
+  static const ifRangeHeader = io.HttpHeaders.IF_RANGE;
+  static const ifUnmodifiedSinceHeader = io.HttpHeaders.IF_UNMODIFIED_SINCE;
+  static const lastModifiedHeader = io.HttpHeaders.LAST_MODIFIED;
+  static const locationHeader = io.HttpHeaders.LOCATION;
+  static const maxForwardsHeader = io.HttpHeaders.MAX_FORWARDS;
+  static const pragmaHeader = io.HttpHeaders.PRAGMA;
+  static const proxyAuthenticateHeader = io.HttpHeaders.PROXY_AUTHENTICATE;
+  static const proxyAuthorizationHeader = io.HttpHeaders.PROXY_AUTHORIZATION;
+  static const rangeHeader = io.HttpHeaders.RANGE;
+  static const refererHeader = io.HttpHeaders.REFERER;
+  static const retryAfterHeader = io.HttpHeaders.RETRY_AFTER;
+  static const serverHeader = io.HttpHeaders.SERVER;
+  static const teHeader = io.HttpHeaders.TE;
+  static const trailerHeader = io.HttpHeaders.TRAILER;
+  static const transferEncodingHeader = io.HttpHeaders.TRANSFER_ENCODING;
+  static const upgradeHeader = io.HttpHeaders.UPGRADE;
+  static const userAgentHeader = io.HttpHeaders.USER_AGENT;
+  static const varyHeader = io.HttpHeaders.VARY;
+  static const viaHeader = io.HttpHeaders.VIA;
+  static const warningHeader = io.HttpHeaders.WARNING;
+  static const wwwAuthenticateHeader = io.HttpHeaders.WWW_AUTHENTICATE;
+  static const cookieHeader = io.HttpHeaders.COOKIE;
+  static const setCookieHeader = io.HttpHeaders.SET_COOKIE;
+  static const generalHeadersHeader = io.HttpHeaders.GENERAL_HEADERS;
+  static const entityHeadersHeader = io.HttpHeaders.ENTITY_HEADERS;
+  static const responseHeadersHeader = io.HttpHeaders.RESPONSE_HEADERS;
+  static const requestHeadersHeader = io.HttpHeaders.REQUEST_HEADERS;
+}
+
 abstract class HttpClient {
   static const defaultHttpPort = io.HttpClient.DEFAULT_HTTP_PORT;
   static const defaultHttpsPort = io.HttpClient.DEFAULT_HTTPS_PORT;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2_constant
-version: 1.0.1+dart1
+version: 1.0.2+dart1
 description: A polyfill for Dart 2 constant names.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/dart2_constant

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/dart2_constant
 
 environment:
-  sdk: '>=1.24.0 <2.0.0-dev.44'
+  sdk: '>=1.24.0 <2.0.0'
 
 dev_dependencies:
   args: "^1.0.0"


### PR DESCRIPTION
I did make a functional change, but there are no tests to update, so I don't know if tests are needed for that case.